### PR TITLE
Refactorización de propiedades en la clase Bocadillo

### DIFF
--- a/src/AppForSEII2526.API/Models/Bocadillo.cs
+++ b/src/AppForSEII2526.API/Models/Bocadillo.cs
@@ -21,7 +21,7 @@ namespace AppForSEII2526.API.Models
         [Required]
         public int TipoPanId { get; set; }
         public string? ResenyaBocadillo { get; set; }
-        public int ComprasDelBocadillo { get; set; }
+        public List<CompraBocadillo> CompraBocadillos { get; set; } = new List<CompraBocadillo>();
 
 
         public int Stock { get; set; }
@@ -34,16 +34,16 @@ namespace AppForSEII2526.API.Models
 
         }
 
-        public Bocadillo(int id, string nombre, decimal pVP, List<CompraBocadillo> comprasDelBocadillo, string? resenyaBocadillo, int stock, int panId, EnumTamaño tamano, List<ResenyaBocadillo> resenyaBocadillos, TipoPan tipoPan)
+        public Bocadillo(int id, string nombre, decimal pVP, EnumTamaño tamano, int tipoPanId, string? resenyaBocadillo, List<CompraBocadillo> compraBocadillos, int stock, List<ResenyaBocadillo> resenyaBocadillos, TipoPan tipoPan)
         {
             Id = id;
             Nombre = nombre;
             PVP = pVP;
-            CompraBocadillos = comprasDelBocadillo;
-            ResenyaBocadillo = resenyaBocadillo;
-            Stock = stock;
-            TipoPanId = panId;
             Tamano = tamano;
+            TipoPanId = tipoPanId;
+            ResenyaBocadillo = resenyaBocadillo;
+            CompraBocadillos = compraBocadillos;
+            Stock = stock;
             ResenyaBocadillos = resenyaBocadillos;
             TipoPan = tipoPan;
         }
@@ -54,11 +54,11 @@ namespace AppForSEII2526.API.Models
                    Id == bocadillo.Id &&
                    Nombre == bocadillo.Nombre &&
                    PVP == bocadillo.PVP &&
-                   EqualityComparer<List<CompraBocadillo>>.Default.Equals(CompraBocadillos, bocadillo.CompraBocadillos) &&
-                   ResenyaBocadillo == bocadillo.ResenyaBocadillo &&
-                   Stock == bocadillo.Stock &&
-                   TipoPanId == bocadillo.TipoPanId &&
                    Tamano == bocadillo.Tamano &&
+                   TipoPanId == bocadillo.TipoPanId &&
+                   ResenyaBocadillo == bocadillo.ResenyaBocadillo &&
+                   EqualityComparer<List<CompraBocadillo>>.Default.Equals(CompraBocadillos, bocadillo.CompraBocadillos) &&
+                   Stock == bocadillo.Stock &&
                    EqualityComparer<List<ResenyaBocadillo>>.Default.Equals(ResenyaBocadillos, bocadillo.ResenyaBocadillos) &&
                    EqualityComparer<TipoPan>.Default.Equals(TipoPan, bocadillo.TipoPan);
         }
@@ -69,11 +69,11 @@ namespace AppForSEII2526.API.Models
             hash.Add(Id);
             hash.Add(Nombre);
             hash.Add(PVP);
-            hash.Add(CompraBocadillos);
-            hash.Add(ResenyaBocadillo);
-            hash.Add(Stock);
-            hash.Add(TipoPanId);
             hash.Add(Tamano);
+            hash.Add(TipoPanId);
+            hash.Add(ResenyaBocadillo);
+            hash.Add(CompraBocadillos);
+            hash.Add(Stock);
             hash.Add(ResenyaBocadillos);
             hash.Add(TipoPan);
             return hash.ToHashCode();


### PR DESCRIPTION
Se reemplazó la propiedad `ComprasDelBocadillo` (int) por `CompraBocadillos` (lista de objetos `CompraBocadillo`). Se actualizó el constructor para reflejar estos cambios, reorganizando parámetros y corrigiendo asignaciones. Se ajustaron los métodos `Equals` y `GetHashCode` para incluir las nuevas propiedades y eliminar redundancias.
#26 