### PR TITLE
Hacer nullable la propiedad DireccionEnvio

### DIFF
--- a/src/AppForSEII2526.API/Models/ApplicationUser.cs
+++ b/src/AppForSEII2526.API/Models/ApplicationUser.cs
@@ -36,5 +36,6 @@ public class ApplicationUser : IdentityUser
 
  
     public List<CompraBono> Compras { get; set; }
-    public string DireccionEnvio { get; set; } // <-- Añadir esta propiedad
+
+    public string? DireccionEnvio { get; set; } 
 }


### PR DESCRIPTION
Se ha actualizado la clase `ApplicationUser` en el archivo `ApplicationUser.cs` para modificar la propiedad `DireccionEnvio`. La propiedad ha pasado de ser un `string` no nullable a un `string?` nullable, permitiendo valores nulos.